### PR TITLE
Changed default tag to <div>

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -19,7 +19,7 @@ export function getTag() {
     // You must call this within a function scope, not globally, or else it will not be updated if a test updates it programmatically.
     const tagSetting = workspace.getConfiguration().get<string>("htmltagwrap.tag");
     if (!tagSetting) {
-        return 'p'; 
+        return 'div'; 
     }
     return tagSetting;
 }


### PR DESCRIPTION
`<div>` as a default tag is more practical than `<p>`.