### PR TITLE
Change tagSetting check from falsy to undefined

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -18,7 +18,7 @@ export function announceNotableUpdate (extensionContext: ExtensionContext) {
 export function getTag() {
     // You must call this within a function scope, not globally, or else it will not be updated if a test updates it programmatically.
     const tagSetting = workspace.getConfiguration().get<string>("htmltagwrap.tag");
-    if (!tagSetting) {
+    if (tagSetting === undefined) {
         return 'p'; 
     }
     return tagSetting;


### PR DESCRIPTION
- Behaviour: Setting `"htmltagwrap.tag": ""` still wraps with `p`.
- Cause: `if (!tagSetting)` treats empty string as falsy.
- Solution: https://code.visualstudio.com/api/references/vscode-api#WorkspaceConfiguration specifies that the `get` method returns the value as specified in the settings otherwise `undefined`, hence we only need to check for `undefined`.